### PR TITLE
Fix voor output/OSX build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,10 +487,10 @@ add_definitions(-DRTI_USES_STD_FSTREAM)
 # The toggle to linker flag is a "quick fix" to avoid that
 # but this is not the end of the story we need to fix it for good.
 if (APPLE)
-   SET (CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS_INIT} "-flat_namespace -undefined suppress"
+   SET (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS_INIT} -flat_namespace -undefined suppress"
         CACHE STRING "Flags used by the linker during the creation of dll's." FORCE)
    # module linker flags
-   SET (CMAKE_MODULE_LINKER_FLAGS ${CMAKE_MODULE_LINKER_FLAGS_INIT} "-flat_namespace -undefined suppress"
+   SET (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS_INIT} -flat_namespace -undefined suppress"
         CACHE STRING "Flags used by the linker during the creation of modules." FORCE)
 
    #set(PROPERTY LINK_FLAGS_DEBUG "-flat_namespace -undefined suppress")

--- a/README
+++ b/README
@@ -1,4 +1,6 @@
-Mirror van de CERTI_Clone op https://github.com/JorisSteneker/CERTI_Clone. Deze versie heeft wel één extra commit waarin het compileren op Mac OS gerepareerd is op basis van de bugs gerapporteerd op de bugtracker van de officiële CERTI op https://savannah.nongnu.org/bugs/?group=certi.
+Mirror van de CERTI_Clone op https://github.com/JorisSteneker/CERTI_Clone. 
+Deze versie heeft wel één extra commit waarin het compileren op Mac OS gerepareerd is op basis 
+van de bugs gerapporteerd op de bugtracker van de officiële CERTI op https://savannah.nongnu.org/bugs/?group=certi.
 
 License
 -------

--- a/README
+++ b/README
@@ -1,3 +1,4 @@
+Mirror van de CERTI_Clone op https://github.com/JorisSteneker/CERTI_Clone. Deze versie heeft wel één extra commit waarin het compileren op Mac OS gerepareerd is op basis van de bugs gerapporteerd op de bugtracker van de officiële CERTI op https://savannah.nongnu.org/bugs/?group=certi.
 
 License
 -------

--- a/README
+++ b/README
@@ -1,7 +1,3 @@
-Mirror van de CERTI_Clone op https://github.com/JorisSteneker/CERTI_Clone. 
-Deze versie heeft wel één extra commit waarin het compileren op Mac OS gerepareerd is op basis 
-van de bugs gerapporteerd op de bugtracker van de officiële CERTI op https://savannah.nongnu.org/bugs/?group=certi.
-
 License
 -------
 

--- a/RTIG/RTIG_processing.cc
+++ b/RTIG/RTIG_processing.cc
@@ -145,7 +145,7 @@ RTIG::processJoinFederation(Socket *link, NM_Join_Federation_Execution *req)
 		throw RTIinternalError("Invalid Federation/Federate Name.");
 
 	std::cout << "\nFederate \"" << federate << "\" joins Federation \""
-			<< federation << "\"";
+			<< federation << "\"" << std::flush;
 
 	Handle num_federation = federations.getFederationHandle(federation);
 
@@ -191,7 +191,7 @@ RTIG::processJoinFederation(Socket *link, NM_Join_Federation_Execution *req)
 			peer);
 
     std::cout << "(" << num_federation << ") with handle " << num_federe
-			<< ". Socket " << int(link->returnSocket()) <<" and IP-address " << link->addr2string(address) << "\n";
+			<< ". Socket " << int(link->returnSocket()) <<" and IP-address " << link->addr2string(address) << "\n" << std::flush;
 
 	// Prepare answer about JoinFederationExecution
 	rep.setFederationName(federation);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,8 +3,51 @@ add_subdirectory(Billard)
 add_subdirectory(utility)
 add_subdirectory(testFederate)
 
+# bug #55104 Test if rpc include directory is available
+# reason is Fedora removed (in v28) the rpc header from the standard glibc
+set(RPC_DEFAULT_INCLUDE_PATHS
+    ${CMAKE_CURRENT_LIST_DIR}/..     
+    /usr/local/include
+    /usr/include
+    /usr/include/tirpc
+    /opt/include
+    )
+    
+set(RPC_DEFAULT_LIB_PATHS
+    ${CMAKE_CURRENT_LIST_DIR}/..     
+    /usr/local/lib
+    /usr/local/lib64
+    /usr/lib
+    /usr/lib64
+    /opt/
+    )
+
+FIND_PATH(RPC_INCLUDE_DIR
+	NAMES "rpc/rpc.h"
+	HINTS /usr/include/tirpc
+	PATHS ${RPC_DEFAULT_INCLUDE_PATHS}
+	)
+
+FIND_LIBRARY(RPCLIB_LIBS
+    NAMES librpc rpclib rpc tirpc
+	PATHS ${RPC_DEFAULT_LIB_PATHS}
+	)
+	
+if(NOT RPC_INCLUDE_DIR)
+    MESSAGE("Could not find RPC Headers, certiCheckHostAndIP test won't be compiled!")
+else()
+	MESSAGE("RPC Headers found in ${RPC_INCLUDE_DIR}")
+	INCLUDE_DIRECTORIES(${RPC_INCLUDE_DIR})
+endif()
+
+if(NOT RPCLIB_LIBS)
+    MESSAGE("Could not find RPC Libraries, certiCheckHostAndIP test won't be compiled!")
+else()
+	MESSAGE("RPC Libraries found in found in ${RPCLIB_LIBS}")
+endif()
+
 # Do not compile this on Win32 (not very useful)
-if (NOT WIN32)
+if ((NOT WIN32) AND (RPC_INCLUDE_DIR) AND (RPCLIB_LIBS))
    if (CMAKE_SYSTEM_NAME MATCHES "Linux")
       set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/certiCheckHostAndIP.c PROPERTIES COMPILE_DEFINITIONS "LINUX")
    endif()
@@ -12,6 +55,7 @@ if (NOT WIN32)
    if(COMPILE_WITH_C11)
     set_property(TARGET CertiCheckHostAndIP PROPERTY C_STANDARD 11)
    endif()
+   target_link_libraries(CertiCheckHostAndIP ${RPCLIB_LIBS})
    install(TARGETS CertiCheckHostAndIP
            RUNTIME DESTINATION bin
            LIBRARY DESTINATION lib


### PR DESCRIPTION
Als het proces extern gestart wordt is de output nu goed te lezen (federate joined berichten ontbraken).

Ook inclusief fixes voor CERTI compilatie op OSX.